### PR TITLE
add password field to MPDClient()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The config file is located at `~/.config/miniplayer/config`. The example configu
 #### mpd
 * ***host*:** The mpd host
 * ***port*:** The mpd port
+* ***pass*:** The mpd password
 
 
 ## Keybinds

--- a/bin/miniplayer
+++ b/bin/miniplayer
@@ -23,7 +23,8 @@ if "player" not in config.sections():
 
 if "mpd" not in config.sections():
     config["mpd"] = {"host": "localhost",
-                     "port": "6600"
+                     "port": "6600",
+                     "pass": False
                      }
 
 player_config = config["player"]
@@ -45,6 +46,7 @@ MUSICDIR = os.path.expanduser(MUSICDIR)
 # MPD config
 MPDHOST = mpd_config.get("host", "localhost")
 MPDPORT = mpd_config.getint("port", 6600)
+MPDPASS = mpd_config.get("pass", False)
 
 # What to use to draw images
 IMAGEMETHOD = player_config.get("image_method", "pixcat")
@@ -86,6 +88,8 @@ class Player:
         # MPD init
         self.client = MPDClient()
         self.client.connect(MPDHOST, MPDPORT)
+        if MPDPASS:
+            self.client.password(MPDPASS)
 
         self.last_song = None
 

--- a/config.example
+++ b/config.example
@@ -7,4 +7,4 @@ image_method = pixcat
 [mpd]
 host = localhost
 port = 6600
-pass = example
+# pass = example

--- a/config.example
+++ b/config.example
@@ -7,3 +7,4 @@ image_method = pixcat
 [mpd]
 host = localhost
 port = 6600
+pass = example


### PR DESCRIPTION
Changes:
- Included a "pass" field in the default config.
- Added `MPDClient().password()` for password protected clients.