### PR TITLE
Fixed tracks with multiple artists causing crashes and rendering issues

### DIFF
--- a/bin/miniplayer
+++ b/bin/miniplayer
@@ -623,6 +623,9 @@ class Player:
         except KeyError:
             artist = ""
 
+        if type(artist) is list:
+            artist = ", ".join(artist)
+
         try:
             title = song["title"]
         except KeyError:


### PR DESCRIPTION
I've found a bug with how multiple artists are handled. When a track has multiple artists, they are stored in a list, however miniplayer wrongly assumes that they are a single string, thus causing unexpected behavior like this:
```
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
                                     ['Maxim Shostakovich', 'Prague Symphony Orche
Symphony No. 13 in B-Flat Min...     ['Maxim Shostakovich', 'Prague Symphony Orche
Shostakovich: Symphonies - Co...     ['Maxim Shostakovich', 'Prague Symphony Orche
['Maxim Shostakovich', 'Prague Sy    ['Maxim Shostakovich', 'Prague Symphony Orche
────╶y Orchestra', 'Prague Philha    ['Maxim Shostakovich', 'Prague Symphony Orche
                       1:50/13:38    ['Maxim Shostakovich', 'Prague Symphony Orche
, 'Pavel Kühn', 'Peter Mikulas']     ['Maxim Shostakovich', 'Prague Symphony Orche
```
Notice how at the bottom-left corner artists are printed over four lines, while they normally should be stripped to fit one line. In this case, miniplayer assumes that `len(artist)` is the width of the artist string, but since `artist` is a list, it uses number of artists as the string width, thus printing potentially large string. This behavior also leads to crashes if unstripped artists string doesn't fit the window.

I added code to compile artists to a single string, so the output would look like this:
```
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
Symphony No. 13 in B-Flat...      Maxim Shostakovich, Prague Symphony Orche
Shostakovich: Symphonies -...     Maxim Shostakovich, Prague Symphony Orche
Maxim Shostakovich, Prague...     Maxim Shostakovich, Prague Symphony Orche
╶                                 Maxim Shostakovich, Prague Symphony Orche
                    0:01/12:53    Maxim Shostakovich, Prague Symphony Orche
                                  Maxim Shostakovich, Prague Symphony Orche
```