### PR TITLE
check for NoneType when getting dominant or secondary colors

### DIFF
--- a/bin/miniplayer
+++ b/bin/miniplayer
@@ -425,8 +425,13 @@ class Player:
         color.
         """
 
+        palette = self.getColorPalette()
+
+        if palette is None or len(palette) < 1:
+            return
+        
         # Get the dominant color
-        dominant_color = self.getColorPalette()[0][1]
+        dominant_color = palette[0][1]
 
         # Cast the color to curses range
         col = [round(1000 * val/255) for val in dominant_color]
@@ -447,8 +452,14 @@ class Player:
         color.
         """
 
-        # Get the dominant color
-        secondary_color = self.getColorPalette()[1][1]
+        palette = self.getColorPalette()
+
+        # There must be two elements to get a secondary
+        if palette is None or len(palette) < 2:
+            return
+        
+        # Get the secondary color
+        secondary_color = palette[1][1]
 
         # Cast the color to curses range
         col = [round(1000 * val/255) for val in secondary_color]


### PR DESCRIPTION
Sorry to give more PRs before v2, this just a small bug fix. Originally when opening miniplayer for the first time the `/tmp/aartminip.png` is not populated if there is not music playing. This results in all calls to `getColorPalette()` returning `NoneType` and will crash miniplayer with a "NoneType is not subscriptable" exception upon trying to get either the dominant or secondary colors. This PR fixes that by checking if the returned value is `None` and just in case checks if it contains at least one element befor getting the dominant color and at least two elements for the secondary color. These functions now return early if those checks fail.