### PR TITLE
remove redundant curses calls

### DIFF
--- a/bin/miniplayer
+++ b/bin/miniplayer
@@ -1599,8 +1599,6 @@ class Player:
         except pixcat.terminal.KittyAnswerTimeout:
             self.error = "Kitty did not answer in time. Are you using Kitty?"
         finally:
-            curses.nocbreak()
-            curses.endwin()
             self.client.close()
             self.client.disconnect()
             if self.error:


### PR DESCRIPTION
Every time `miniplayer` closes there's an error from a curses call - looks like its because the `curses.endwin()` function is called twice, once in the `Player.loop()` function, and again the the `finally` clause at the end of the script. PR removes the call in `Player.loop()` as the call at the script's end should be made every time the program exits. Removing the duplicate call prevents curses from throwing on quit.